### PR TITLE
feat: add CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.gdljs.com


### PR DESCRIPTION
Add CNAME, we have DNS records pointing to gdljs.github.io already set.